### PR TITLE
docs: AUR installation/pkgbuild, cleanup

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Kainoa Kanter <kainoa@t1c.dev>
+
+_pkgname=cdpcurl
+pkgname="$_pkgname-git"
+pkgver=r12.g8dc4b89
+pkgrel=1
+pkgdesc='CLI for the Coinbase Developer Platform (CDP)'
+url='https://github.com/coinbase/cdpcurl'
+arch=('aarch64' 'i686' 'x86_64')
+license=('custom:none')
+depends=('glibc')
+makedepends=('git' 'go')
+provides=("$_pkgname")
+source=("$_pkgname::git+$url")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}/${_pkgname}" || exit
+    printf "r%s.g%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+	cd "$_pkgname"
+	go mod download
+}
+
+build() {
+	export CGO_CPPFLAGS="${CPPFLAGS}"
+	export CGO_CFLAGS="${CFLAGS}"
+	export CGO_CXXFLAGS="${CXXFLAGS}"
+	export CGO_LDFLAGS="${LDFLAGS}"
+	export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
+	cd "$_pkgname"
+	go build
+}
+
+check() {
+	export CGO_CPPFLAGS="${CPPFLAGS}"
+	export CGO_CFLAGS="${CFLAGS}"
+	export CGO_CXXFLAGS="${CXXFLAGS}"
+	export CGO_LDFLAGS="${LDFLAGS}"
+	export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
+	cd "$_pkgname"
+	go test ./...
+}
+
+package() {
+	cd "$_pkgname"
+	install -Dv cdpcurl -t "$pkgdir/usr/bin/"
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,9 +1,10 @@
+# Maintainer: Di Mei <di.mei@coinbase.com>
 # Maintainer: Kainoa Kanter <kainoa@t1c.dev>
 
 _pkgname=cdpcurl
 pkgname="$_pkgname-git"
 pkgver=r12.g8dc4b89
-pkgrel=1
+pkgrel=2
 pkgdesc='CLI for the Coinbase Developer Platform (CDP)'
 url='https://github.com/coinbase/cdpcurl'
 arch=('aarch64' 'i686' 'x86_64')

--- a/README.md
+++ b/README.md
@@ -2,25 +2,41 @@
 
 `cdpcurl` is a tool that allows you to make HTTP requests to the Coinbase API with your CDP (Coinbase Developer Platform) API key. It is a wrapper around curl that automatically adds the necessary headers to authenticate your requests.
 
-## Installation via Homebrew
-```
+## Installation
+
+## Homebrew
+
+```bash
 brew tap coinbase/cdpcurl
 brew install cdpcurl
 ```
 
-## Installation via Go
-`go install github.com/coinbase/cdpcurl@latest`
+### AUR
+
+```bash
+yay -S cdpcurl-git
+```
+
+### Go
+
+```bash
+go install github.com/coinbase/cdpcurl@latest
+```
 
 ## Example Usage
+
 ### Get account balance of BTC with Sign In With Coinbase API
-```
+```bash
 cdpcurl -k ~/Downloads/cdp_api_key.json 'https://api.coinbase.com/v2/accounts/BTC'
 ```
+
 ### Get the latest price of BTC with Advanced Trading API
-```
+```bash
 cdpcurl -k ~/Downloads/cdp_api_key.json 'https://api.coinbase.com/api/v3/brokerage/products/BTC-USDC'
 ```
+
 ### Create a wallet on Base Sepolia with Platform API
-```
+
+```bash
 cdpcurl -k ~/Downloads/cdp_api_key.json -X POST -d '{"wallet": {"network_id": "base-sepolia"}}' 'https://api.developer.coinbase.com/platform/v1/wallets'
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-## Homebrew
+### Homebrew
 
 ```bash
 brew tap coinbase/cdpcurl


### PR DESCRIPTION
### Changes:

- Adds AUR installation method: <https://aur.archlinux.org/packages/cdpcurl-git> (submitted and maintained by me, [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=cdpcurl-git))
- Consistent formatting for installation section in docs
- Language prefixes for all codeblocks