### PR TITLE
feat: Make printing metadata to screen optional behind cmd flags.

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	version = "v0.0.6"
+	version = "v0.0.7"
 )
 
 var versionCmd = &cobra.Command{
@@ -29,7 +29,7 @@ var versionCmd = &cobra.Command{
 
 func main() {
 	var data, method, apiKeyPath, header string
-	var versionFlag bool
+	var versionFlag, statusFlag, debugFlag bool
 	var id, secret string
 
 	cmd := &cobra.Command{
@@ -45,7 +45,10 @@ func main() {
 				return fmt.Errorf("URL is required unless using -v")
 			}
 
-			opts := []transport.Option{}
+			opts := []transport.Option{
+				transport.WithDebug(debugFlag),
+			}
+
 			if apiKeyPath != "" {
 				opts = append(opts, transport.WithAPIKeyLoaderOption(transport.WithPath(apiKeyPath)))
 			}
@@ -94,8 +97,12 @@ func main() {
 				return err
 			}
 
-			// Print HTTP status code and response body
-			fmt.Println(resp.Status)
+			// Print HTTP status code only if the status flag is set
+			if statusFlag {
+				fmt.Println(resp.Status)
+			}
+
+			// Always print the response body
 			fmt.Println(string(body))
 			return nil
 		},
@@ -108,6 +115,8 @@ func main() {
 	cmd.Flags().BoolVarP(&versionFlag, "version", "v", false, "Print the version number and exit")
 	cmd.Flags().StringVarP(&id, "id", "i", "", "API Key ID (only works with Ed25519 keys)")
 	cmd.Flags().StringVarP(&secret, "secret", "s", "", "API Key Secret (only works with Ed25519 keys)")
+	cmd.Flags().BoolVarP(&statusFlag, "status", "S", false, "Print the HTTP status code in addition to the response body")
+	cmd.Flags().BoolVarP(&debugFlag, "debug", "D", false, "Enable debug mode")
 
 	cmd.AddCommand(versionCmd)
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -21,12 +21,14 @@ type transport struct {
 	originalTransport http.RoundTripper
 	authenticator     *auth.Authenticator
 	serviceName       string
+	debug             bool
 }
 
 type Option func(o *options)
 
 type options struct {
 	apiKey *auth.APIKey
+	debug  bool
 
 	apiKeyOptions []auth.LoadAPIKeyOption
 }
@@ -40,6 +42,12 @@ func WithAPIKeyLoaderOption(opt auth.LoadAPIKeyOption) Option {
 func WithAPIKey(apiKey *auth.APIKey) Option {
 	return func(o *options) {
 		o.apiKey = apiKey
+	}
+}
+
+func WithDebug(debug bool) Option {
+	return func(o *options) {
+		o.debug = debug
 	}
 }
 
@@ -65,6 +73,7 @@ func New(service string, originalTransport http.RoundTripper, opts ...Option) (h
 		originalTransport: originalTransport,
 		authenticator:     authenticator,
 		serviceName:       service,
+		debug:             o.debug,
 	}, nil
 }
 
@@ -76,6 +85,11 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if t.debug {
+		fmt.Println(jwt)
+	}
+
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", jwt))
 	return t.originalTransport.RoundTrip(req)
 }


### PR DESCRIPTION
This PR helps make printing of metadata such as status code, JWT to screen optional behind explicit flags.

This allows the response body (if json) to directly be piped into tools such as jq.

### Before

```
>> cdpcurl -k <API_KEY> https://api.cdp.coinbase.com/platform/v1/networks/ethereum-mainnet/addresses/0x87Bf57c3d7B211a100ee4d00dee08435130A62fA/reputation | jq .
200
jq: parse error: Invalid numeric literal at line 2, column 0
```

### After

```
>> cdpcurl -k <API_KEY>https://api.cdp.coinbase.com/platform/v1/networks/ethereum-mainnet/addresses/0x87Bf57c3d7B211a100ee4d00dee08435130A62fA/reputation | jq .
{
  "metadata": {
    "activity_period_days": 631,
    "bridge_transactions_performed": 4,
    "current_active_streak": 0,
    "ens_contract_interactions": 0,
    "lend_borrow_stake_transactions": 29,
    "longest_active_streak": 3,
    "smart_contract_deployments": 0,
    "token_swaps_performed": 0,
    "total_transactions": 102,
    "unique_days_active": 55
  },
  "score": 51
}
```